### PR TITLE
Remove references for unused packages

### DIFF
--- a/template/dotnet8-csharp/function/Function.csproj
+++ b/template/dotnet8-csharp/function/Function.csproj
@@ -10,9 +10,4 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
## Description

Remove unused package references from the function template:
- `Microsoft.AspNetCore.OpenApi" Version="8.0.3"`
- `Swashbuckle.AspNetCore" Version="6.4.0"`

## Motivation

The OpenAPI document generation is no longer included in the function template.