### PR TITLE
Fix invalid fprocess

### DIFF
--- a/template/dotnet8-csharp/template.yml
+++ b/template/dotnet8-csharp/template.yml
@@ -1,5 +1,5 @@
 language: dotnet8-csharp
-fprocess: dotnet ./root.dll
+fprocess: dotnet ./Root.dll
 welcome_message: |
   You have created a function using C#, dotnet 8 and 
   WebApplication using the minimal API style.


### PR DESCRIPTION
## Description

Change the fprocess in template.yml to `dotnet Root.dll`

## Motivation and context

Functions failed to start because `root.dll` was not found. 