### PR TITLE
Add support for static files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,14 @@ export PREFIX="ttl.sh"
 faas-cli new --lang dotnet8-csharp $PREFIX hello-world
 ```
 
+## Adding static files
+
+If a folder named static is found in the root of your function's source code, **it will be copied** into the final image published for your function.
+
+To serve the contents of the static folder you can setup the file server in `Handler.cs`.
+
+```c#
+    public static void MapEndpoints(WebApplication app) {
+        app.UseStaticFiles();
+    }
+```

--- a/template/dotnet8-csharp/Dockerfile
+++ b/template/dotnet8-csharp/Dockerfile
@@ -14,12 +14,15 @@ RUN dotnet restore Root.csproj
 COPY . .
 RUN dotnet publish -c release -o /app
 
+RUN mkdir -p function/static
+
 FROM --platform=${TARGETPLATFORM:-linux/amd64}  mcr.microsoft.com/dotnet/aspnet:8.0
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 WORKDIR /app
 COPY --from=build /app .
+COPY --from=build src/function/static static
 
 USER app
 

--- a/template/dotnet8-csharp/Program.cs
+++ b/template/dotnet8-csharp/Program.cs
@@ -3,7 +3,9 @@
 
 using function;
 
-var builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateBuilder(new WebApplicationOptions {
+    WebRootPath = "static"
+});
 
 Handler.MapServices(builder.Services);
 


### PR DESCRIPTION
## Description

Support adding static files to functions created with the `dotnet8-csharp` template. All files added in the `static`
folder will be copied into the function image.

The `WebRootPath` has been configured as `static` instead of `wwwroot` to support serving static files by adding middleware like `app.UseFileServer()`. 

## Motivation and context

Support the same functionality as other OpenFaaS templates.

## How has this been tested.

- Verified static files are copied into the function image and can be served.
- Verified the build succeeds when no static folder is present.